### PR TITLE
emmended file pull from single file to inlcude images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 # Ignore CSV files (user-submitted data)
 *.csv
 
+*.html
 # Ignore the personal configuration file
 config.json

--- a/Src/Spaced_Memory_Review.py
+++ b/Src/Spaced_Memory_Review.py
@@ -187,7 +187,7 @@ class SpacedMemoryReview:
                 # Insert links if available
                 for link in self.links:
                     f.write(f'<li><a href="{link.strip()}" target="_blank">{link.strip()}</a></li><br>\n')
-                f.write('</ul><br id="end">')
+                f.write('</ul><p id="end"></p>')
                 f.write("</section>\n</body>\n</html>")
 
         
@@ -274,20 +274,25 @@ class SpacedMemoryReview:
             
             for index, i in enumerate(files):
                 if len(str(i)) > 4:
-                    
+                    blank = False
                     with open(i, "r") as single_file:
                         full_content = single_file.read()
                         # Find the content within <section> tags
                         section_start = full_content.find('<div id=date>')
-                        section_end = full_content.find('<br id="end">', section_start)
+                        section_end = full_content.find('<p id="end">', section_start)
 
-                        section_content = full_content[section_start:section_end+len('</ul>')]
+                        section_content = full_content[section_start:section_end+len('<p id="end">')]
                         
                         #rev_file.write(dates[files.index(i)] + "<br><br>\n")
                         rev_file.write(section_content)
-                else:
+                else: 
+                        blank = True
                         rev_file.write(f"<h2>No material to review for {dates[index]}.</h2>")
-                        
+            if blank:
+                print('')
+            else:
+                rev_file.write("</section></body></html>")
+      
         file_path = os.path.abspath(review_file)
         print(f"Opening file in Edge: {file_path}")
        

--- a/Src/Spaced_Memory_Review.py
+++ b/Src/Spaced_Memory_Review.py
@@ -187,7 +187,7 @@ class SpacedMemoryReview:
                 # Insert links if available
                 for link in self.links:
                     f.write(f'<li><a href="{link.strip()}" target="_blank">{link.strip()}</a></li><br>\n')
-                f.write("</ul>\n")
+                f.write('</ul><br id="end">')
                 f.write("</section>\n</body>\n</html>")
 
         
@@ -279,7 +279,7 @@ class SpacedMemoryReview:
                         full_content = single_file.read()
                         # Find the content within <section> tags
                         section_start = full_content.find('<div id=date>')
-                        section_end = full_content.find('</ul>', section_start)
+                        section_end = full_content.find('<br id="end">', section_start)
 
                         section_content = full_content[section_start:section_end+len('</ul>')]
                         


### PR DESCRIPTION
The review file was not showing my image. 

I realized that it was only pulling from the single file up until the `</ul>` tag, assuming the links. 

However, this was mistaken as the **_text_** may also have a `<ul>` tags. 

We inserted a `<br>` tag with an id of _**end**_ to be used as the stopping point instead.